### PR TITLE
Compilation error due to stale import

### DIFF
--- a/java/AoJ/src/com/oracle/adbaoverjdbc/com/oracle/adbaoverjdbc/OperationGroup.java
+++ b/java/AoJ/src/com/oracle/adbaoverjdbc/com/oracle/adbaoverjdbc/OperationGroup.java
@@ -32,7 +32,6 @@ import java.util.concurrent.Flow;
 import java.util.function.Consumer;
 import java.util.logging.Logger;
 import java.util.stream.Collector;
-import jdk.incubator.sql2.MultiOperation;
 
 /**
  * Only sequential, dependent, unconditional supported.


### PR DESCRIPTION
This class imports:

```java
import jdk.incubator.sql2.MultiOperation;
```

But the linked snapshot does not contain such a class (anymore?)
http://hg.openjdk.java.net/jdk/sandbox/file/9d3b0eb749a9/src/jdk.incubator.adba/share/classes/jdk/incubator/sql2

In fact, a few other things don't compile. Looks like the examples are not in sync with the sandbox version linked from here: https://github.com/oracle/oracle-db-examples/blob/master/java/AoJ/README.md