### PR TITLE
Exception thrown in RowOperation.getIdentifiers()

### DIFF
--- a/java/AoJ/src/com/oracle/adbaoverjdbc/com/oracle/adbaoverjdbc/RowOperation.java
+++ b/java/AoJ/src/com/oracle/adbaoverjdbc/com/oracle/adbaoverjdbc/RowOperation.java
@@ -192,7 +192,7 @@ class RowOperation<T>  extends ParameterizedOperation<T>
         int count = md.getColumnCount();
         identifiers = new String[count];
         for (int i = 0; i < count; i++) {
-          identifiers[i] = md.getColumnName(i);
+          identifiers[i] = md.getColumnName(i + 1);
         }
       }
       catch (SQLException ex) {


### PR DESCRIPTION
JDBC API is 1-based, not 0-based