### PR TITLE
License doc should be single source of truth

### DIFF
--- a/optimizer/spm_fix/example.lst
+++ b/optimizer/spm_fix/example.lst
@@ -308,11 +308,6 @@ SQL> DECLARE
  41        parameter => 'ALTERNATE_PLAN_BASELINE',
  42        value     => 'EXISTING');
  43  
- 44  --
- 45  -- You can use CURSOR_CACHE+SQL_TUNING_SET+AUTOMATIC_WORKLOAD_REPOSITORY
- 46  -- if you have the Oracle Tuning and Oracle Diagnostic Packs.
- 47  -- See Oracle License Guide for details.
- 48  --
  49     DBMS_SPM.SET_EVOLVE_TASK_PARAMETER(
  50        task_name => tname,
  51        parameter => 'ALTERNATE_PLAN_SOURCE',

--- a/optimizer/spm_fix/example.sql
+++ b/optimizer/spm_fix/example.sql
@@ -15,10 +15,6 @@ connect spmdemo/spmdemo
 -- Run the testq1 multiple times and capture in AWR
 -- Assuming a SQL Disagnostics Pack licence.
 --
--- We could also load Q1 into a SQL Tuning Set because
--- this source is also searched by SPM for previous plans.
--- SQL tuning sets required a SQL Tuning Pack licence.
---
 @@q1many
 --
 -- Induce a bad plan for Q1 by dropping the histograms

--- a/optimizer/spm_fix/spm.lst
+++ b/optimizer/spm_fix/spm.lst
@@ -48,11 +48,6 @@ SQL> DECLARE
  41        parameter => 'ALTERNATE_PLAN_BASELINE',
  42        value     => 'EXISTING');
  43  
- 44  --
- 45  -- You can use CURSOR_CACHE+SQL_TUNING_SET+AUTOMATIC_WORKLOAD_REPOSITORY
- 46  -- if you have the Oracle Tuning and Oracle Diagnostic Packs.
- 47  -- See Oracle License Guide for details.
- 48  --
  49     DBMS_SPM.SET_EVOLVE_TASK_PARAMETER(
  50        task_name => tname,
  51        parameter => 'ALTERNATE_PLAN_SOURCE',

--- a/optimizer/spm_fix/spm.sql
+++ b/optimizer/spm_fix/spm.sql
@@ -82,11 +82,6 @@ BEGIN
       parameter => 'ALTERNATE_PLAN_BASELINE', 
       value     => 'EXISTING');
 
---
--- You can use CURSOR_CACHE+SQL_TUNING_SET+AUTOMATIC_WORKLOAD_REPOSITORY
--- if you have the Oracle Tuning and Oracle Diagnostic Packs.
--- See Oracle License Guide for details.
---
    DBMS_SPM.SET_EVOLVE_TASK_PARAMETER( 
       task_name => tname,
       parameter => 'ALTERNATE_PLAN_SOURCE', 


### PR DESCRIPTION
Remove license specifics since the Oracle docs should be single source of truth.