### PR TITLE
remove invalid table reference tab2 in use_hash hint

### DIFF
--- a/optimizer/creative_w_plan/patch/q1.sql
+++ b/optimizer/creative_w_plan/patch/q1.sql
@@ -1,4 +1,4 @@
-select /* PATCHTEST*/  /*+ USE_HASH(tab1 tab2) */
+select /* PATCHTEST*/  /*+ USE_HASH(tab1) */
 sum(num)
 from   tab1
 where  id in (select id


### PR DESCRIPTION
The reference of `tab2` is invalid. This is also reported by `dbms_xplan`'s hint report.
 
![image](https://user-images.githubusercontent.com/3883171/92927194-859c0b00-f43d-11ea-8fbf-d8128c6ceea8.png)

And here's the screenshot after removing `tab2`:

![image](https://user-images.githubusercontent.com/3883171/92928638-aa917d80-f43f-11ea-8d1e-1427bb8e4d61.png)
