### PR TITLE
[Connection Helper] Sid and Svc regexp pattern allowing dot character

### DIFF
--- a/sqldeveloper/extension/java/ConnectionHelper/src/oracle/db/example/sqldeveloper/extension/connectionHelper/ConnectionHelper.java
+++ b/sqldeveloper/extension/java/ConnectionHelper/src/oracle/db/example/sqldeveloper/extension/connectionHelper/ConnectionHelper.java
@@ -64,7 +64,7 @@ public class ConnectionHelper {
     // TODO? Look up valid character requirements for each group
     // format = -conName=user[/[pw]]@host:port(:sid|/svc)[#role]
     //           1       2      4    5    6     8    9     11
-    private static final String conRegex = "-(.*)=([^\\/]*)(\\/([^@]*))?@([^:]*):([^:]*)(:([a-zA-Z0-9_]*)|\\/([a-zA-Z0-9_]*))(#([a-zA-Z0-9_]*))?"; //$NON-NLS-1$
+    private static final String conRegex = "-(.*)=([^\\/]*)(\\/([^@]*))?@([^:]*):([^:]*)(:([a-zA-Z0-9_.]*)|\\/([a-zA-Z0-9_.]*))(#([a-zA-Z0-9_]*))?"; //$NON-NLS-1$
     private static final Pattern conArg = Pattern.compile(conRegex);
 	
     private static void processPotentialConnectionArgument(String arg, boolean persist) {


### PR DESCRIPTION
The connection helper extension did not work with sid/svc that had dot character in it. The proposed fix is that sid and svc regexp pattern now matches dot characters for more complex urls, in order to fix the problems addressed in #125  that I too had experienced. 
This is such a great extension! Thank you so much, let me know if there is something else I should add to this PR.

Regards,
MF