### PR TITLE
Tinglwan add nativeimage

### DIFF
--- a/java/autonomousdb-wallet-secret-sample/README.md
+++ b/java/autonomousdb-wallet-secret-sample/README.md
@@ -17,6 +17,7 @@ If you want to configure a previously downloaded wallet you can just create the 
 ```sh
 kubectl create secret generic instance-wallet --from-file=<path-to-wallets-unzipped-folder>
 ```
+
 The Java microservice retrieves username, password and url also from a secret. To create it you can use the following script as an example:
 
 ```sh
@@ -25,6 +26,7 @@ kubectl create secret generic user-jdbc \
   --from-literal=password='<password>' \
   --from-literal=url='jdbc:oracle:thin:@<alias-in-tnsnames.ora>'
 ```
+
 ## Install, build and deploy
 
 It is as simple as to build the maven project, create the docker image and deploy the Pod:
@@ -32,6 +34,14 @@ It is as simple as to build the maven project, create the docker image and deplo
 ```sh
 mvn clean install
 docker build -t adb-health-check target
+kubectl apply -f target/app.yaml
+```
+
+If you want to run the application as a [GraalVM Native Image](https://www.graalvm.org/reference-manual/native-image/), simply specify the different Dockerfile `target/Dockerfile.nativeimage` and repeat the rest of the steps.
+
+```sh
+mvn clean install
+docker build -f target/Dockerfile.nativeimage -t adb-health-check target
 kubectl apply -f target/app.yaml
 ```
 

--- a/java/autonomousdb-wallet-secret-sample/README.md
+++ b/java/autonomousdb-wallet-secret-sample/README.md
@@ -37,7 +37,9 @@ docker build -t adb-health-check target
 kubectl apply -f target/app.yaml
 ```
 
-If you want to run the application as a [GraalVM Native Image](https://www.graalvm.org/reference-manual/native-image/), simply specify the different Dockerfile `target/Dockerfile.nativeimage` and repeat the rest of the steps.
+If you want to run the application as a [GraalVM Native Image](https://www.graalvm.org/reference-manual/native-image/), it is very likely that the build process will be frozen since GraalVM Native Image compilation process is really RAM-intensive. To prevent from the issue, we recommend allotting the Docker engine around **9 to 12 GB of RAM**.
+
+After that, simply specify the different Dockerfile `target/Dockerfile.nativeimage` and repeat the rest of the steps. 
 
 ```sh
 mvn clean install

--- a/java/autonomousdb-wallet-secret-sample/pom.xml
+++ b/java/autonomousdb-wallet-secret-sample/pom.xml
@@ -110,6 +110,7 @@
 									<filtering>true</filtering>
 									<includes>
 										<include>Dockerfile</include>
+										<include>Dockerfile.nativeimage</include>
 									</includes>
 								</resource>
 								<resource>

--- a/java/autonomousdb-wallet-secret-sample/src/main/docker/Dockerfile.nativeimage
+++ b/java/autonomousdb-wallet-secret-sample/src/main/docker/Dockerfile.nativeimage
@@ -1,0 +1,22 @@
+FROM ghcr.io/graalvm/graalvm-ce:21.3.0
+RUN gu install native-image
+
+RUN mkdir /app
+COPY libs /app/libs
+COPY ${project.artifactId}.jar /app
+
+RUN native-image -jar /app/${project.artifactId}.jar -H:Name=/app/${project.artifactId}
+
+FROM oraclelinux:8-slim
+RUN mkdir /app
+COPY --from=0 "/app/${project.artifactId}" /app/${project.artifactId}
+WORKDIR /app
+
+# The driver will look for the wallet in folder /app/wallet 
+# This value must match the one in the mountPath of the container
+# Reference in src/main/k8s/app.yaml
+
+CMD ["/app/${project.artifactId}", \
+  "-Doracle.net.tns_admin=/app/wallet", \
+  "-Doracle.net.wallet_location=/app/wallet", \
+  "-Doracle.jdbc.fanEnabled=false"]

--- a/java/autonomousdb-wallet-secret-sample/src/main/docker/Dockerfile.nativeimage
+++ b/java/autonomousdb-wallet-secret-sample/src/main/docker/Dockerfile.nativeimage
@@ -9,7 +9,7 @@ RUN native-image -jar /app/${project.artifactId}.jar -H:Name=/app/${project.arti
 
 FROM oraclelinux:8-slim
 RUN mkdir /app
-COPY --from=0 "/app/${project.artifactId}" /app/${project.artifactId}
+COPY --from=0 "/app/${project.artifactId}" "/app/${project.artifactId}"
 WORKDIR /app
 
 # The driver will look for the wallet in folder /app/wallet 


### PR DESCRIPTION
Add the support to create the container image from the native-executable. 

The Dockerfile `src/main/docker/Dockerfile.nativeimage` builds the native executable directly in a container without having a final container containing the build tools.